### PR TITLE
Upgrade to time 0.2.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 
 *  Use `sha-1` crate instead of unmaintained `sha1` crate
 
-*  Update the `time` dependency to 0.2.2
+*  Update the `time` dependency to 0.2.3
 
 ## [2.0.0] - 2019-12-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ regex = "1.3"
 serde = { version = "1.0", features=["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.2", default-features = false, features = ["std"] }
+time = { version = "0.2.3", default-features = false }
 url = "2.1"
 open-ssl = { version="0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.16.0", package = "rustls", optional = true }

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Update the `time` dependency to 0.2.2
+* Update the `time` dependency to 0.2.3
 
 ## [1.0.1] - 2019-12-20
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -76,7 +76,7 @@ serde_json = "1.0"
 sha-1 = "0.8"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.2", default-features = false, features = ["std"] }
+time = { version = "0.2.3", default-features = false }
 
 # for secure cookie
 ring = { version = "0.16.9", optional = true }

--- a/actix-http/src/config.rs
+++ b/actix-http/src/config.rs
@@ -7,7 +7,6 @@ use std::{fmt, net};
 use actix_rt::time::{delay_for, delay_until, Delay, Instant};
 use bytes::BytesMut;
 use futures_util::{future, FutureExt};
-use time;
 use time::OffsetDateTime;
 
 // "Sun, 06 Nov 1994 08:49:37 GMT".len()

--- a/actix-http/src/cookie/mod.rs
+++ b/actix-http/src/cookie/mod.rs
@@ -992,7 +992,7 @@ impl<'a, 'b> PartialEq<Cookie<'b>> for Cookie<'a> {
 #[cfg(test)]
 mod tests {
     use super::{Cookie, SameSite};
-    use time::{PrimitiveDateTime, UtcOffset};
+    use time::offset;
 
     #[test]
     fn format() {
@@ -1017,7 +1017,7 @@ mod tests {
         assert_eq!(&cookie.to_string(), "foo=bar; Domain=www.rust-lang.org");
 
         let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
-        let expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().using_offset(UtcOffset::UTC);
+        let expires = time::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().using_offset(offset!(UTC));
         let cookie = Cookie::build("foo", "bar").expires(expires).finish();
         assert_eq!(
             &cookie.to_string(),

--- a/actix-http/src/cookie/parse.rs
+++ b/actix-http/src/cookie/parse.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::str::Utf8Error;
 
 use percent_encoding::percent_decode;
-use time::{Duration, PrimitiveDateTime, UtcOffset};
+use time::{Duration, offset};
 
 use super::{Cookie, CookieStr, SameSite};
 
@@ -185,10 +185,10 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
                 // http://tools.ietf.org/html/rfc2616#section-3.3.1. Try
                 // additional ones as encountered in the real world.
                 let tm = time_parser::parse_http_date(v)
-                    .or_else(|| PrimitiveDateTime::parse(v, "%a, %d-%b-%Y %H:%M:%S").ok());
+                    .or_else(|| time::parse(v, "%a, %d-%b-%Y %H:%M:%S").ok());
 
                 if let Some(time) = tm {
-                    cookie.expires = Some(time.using_offset(UtcOffset::UTC))
+                    cookie.expires = Some(time.using_offset(offset!(UTC)))
                 }
             }
             _ => {
@@ -216,7 +216,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Cookie, SameSite};
-    use time::{Duration, PrimitiveDateTime, UtcOffset};
+    use time::Duration;
 
     macro_rules! assert_eq_parse {
         ($string:expr, $expected:expr) => {
@@ -376,7 +376,7 @@ mod tests {
         );
 
         let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
-        let expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().using_offset(UtcOffset::UTC);
+        let expires = time::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().using_offset(offset!(UTC));
         expected.set_expires(expires);
         assert_eq_parse!(
             " foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
@@ -385,7 +385,7 @@ mod tests {
         );
 
         unexpected.set_domain("foo.com");
-        let bad_expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%S:%M").unwrap().using_offset(UtcOffset::UTC);
+        let bad_expires = time::parse(time_str, "%a, %d %b %Y %H:%S:%M").unwrap().using_offset(offset!(UTC));
         expected.set_expires(bad_expires);
         assert_ne_parse!(
             " foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \

--- a/actix-http/src/header/shared/httpdate.rs
+++ b/actix-http/src/header/shared/httpdate.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use bytes::{buf::BufMutExt, BytesMut};
 use http::header::{HeaderValue, InvalidHeaderValue};
-use time::{PrimitiveDateTime, OffsetDateTime, UtcOffset};
+use time::{PrimitiveDateTime, OffsetDateTime, offset};
 
 use crate::error::ParseError;
 use crate::header::IntoHeaderValue;
@@ -20,7 +20,7 @@ impl FromStr for HttpDate {
 
     fn from_str(s: &str) -> Result<HttpDate, ParseError> {
         match time_parser::parse_http_date(s) {
-            Some(t) => Ok(HttpDate(t.using_offset(UtcOffset::UTC))),
+            Some(t) => Ok(HttpDate(t.using_offset(offset!(UTC)))),
             None => Err(ParseError::Header)
         }
     }
@@ -40,7 +40,7 @@ impl From<OffsetDateTime> for HttpDate {
 
 impl From<SystemTime> for HttpDate {
     fn from(sys: SystemTime) -> HttpDate {
-        HttpDate(PrimitiveDateTime::from(sys).using_offset(UtcOffset::UTC))
+        HttpDate(PrimitiveDateTime::from(sys).using_offset(offset!(UTC)))
     }
 }
 
@@ -49,7 +49,7 @@ impl IntoHeaderValue for HttpDate {
 
     fn try_into(self) -> Result<HeaderValue, Self::Error> {
         let mut wrt = BytesMut::with_capacity(29).writer();
-        write!(wrt, "{}", self.0.to_offset(UtcOffset::UTC).format("%a, %d %b %Y %H:%M:%S GMT")).unwrap();
+        write!(wrt, "{}", self.0.to_offset(offset!(UTC)).format("%a, %d %b %Y %H:%M:%S GMT")).unwrap();
         HeaderValue::from_maybe_shared(wrt.get_mut().split().freeze())
     }
 }
@@ -59,25 +59,21 @@ impl From<HttpDate> for SystemTime {
         let dt = date.0;
         let epoch = OffsetDateTime::unix_epoch();
 
-        if dt >= epoch {
-            UNIX_EPOCH + (dt - epoch)
-        } else {
-            UNIX_EPOCH - (epoch - dt)
-        }
+        UNIX_EPOCH + (dt - epoch)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::HttpDate;
-    use time::{PrimitiveDateTime, Date, Time, UtcOffset};
+    use time::{PrimitiveDateTime, date, time, offset};
 
     #[test]
     fn test_date() {
         let nov_07 = HttpDate(PrimitiveDateTime::new(
-            Date::try_from_ymd(1994, 11, 7).unwrap(),
-            Time::try_from_hms(8, 48, 37).unwrap()
-        ).using_offset(UtcOffset::UTC));
+            date!(1994-11-07),
+            time!(8:48:37)
+        ).using_offset(offset!(UTC)));
 
         assert_eq!(
             "Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>().unwrap(),

--- a/actix-http/src/time_parser.rs
+++ b/actix-http/src/time_parser.rs
@@ -9,7 +9,7 @@ pub fn parse_http_date(time: &str) -> Option<PrimitiveDateTime> {
 
 /// Attempt to parse a `time` string as a RFC 1123 formatted date time string.
 fn try_parse_rfc_1123(time: &str) -> Option<PrimitiveDateTime> {
-    PrimitiveDateTime::parse(time, "%a, %d %b %Y %H:%M:%S").ok()
+    time::parse(time, "%a, %d %b %Y %H:%M:%S").ok()
 }
 
 /// Attempt to parse a `time` string as a RFC 850 formatted date time string.
@@ -38,5 +38,5 @@ fn try_parse_rfc_850(time: &str) -> Option<PrimitiveDateTime> {
 
 /// Attempt to parse a `time` string using ANSI C's `asctime` format.
 fn try_parse_asctime(time: &str) -> Option<PrimitiveDateTime> {
-    PrimitiveDateTime::parse(time, "%a %b %_d %H:%M:%S %Y").ok()
+    time::parse(time, "%a %b %_d %H:%M:%S %Y").ok()
 }

--- a/actix-identity/CHANGES.md
+++ b/actix-identity/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [0.2.x] - 2020-01-xx
 
-* Update the `time` dependency to 0.2.2
+* Update the `time` dependency to 0.2.3
 
 ## [0.2.1] - 2020-01-10
 

--- a/actix-identity/Cargo.toml
+++ b/actix-identity/Cargo.toml
@@ -21,7 +21,7 @@ actix-service = "1.0.2"
 futures = "0.3.1"
 serde = "1.0"
 serde_json = "1.0"
-time = { version = "0.2.2", default-features = false, features = ["std"] }
+time = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [0.3.1] - 2020-01-xx
 
-* Update the `time` dependency to 0.2.2
+* Update the `time` dependency to 0.2.3
 
 ## [0.3.0] - 2019-12-20
 

--- a/actix-session/Cargo.toml
+++ b/actix-session/Cargo.toml
@@ -29,7 +29,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 serde = "1.0"
 serde_json = "1.0"
-time = { version = "0.2.2", default-features = false, features = ["std"] }
+time = { version = "0.2.3", default-features = false }
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/actix-session/src/cookie.rs
+++ b/actix-session/src/cookie.rs
@@ -264,7 +264,7 @@ impl CookieSession {
 
     /// Sets the `max-age` field in the session cookie being built.
     pub fn max_age(self, seconds: i64) -> CookieSession {
-        self.max_age_time(time::Duration::seconds(seconds))
+        self.max_age_time(Duration::seconds(seconds))
     }
 
     /// Sets the `max-age` field in the session cookie being built.

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = "1.0"
 sha1 = "0.6"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.2", default-features = false, features = ["std"] }
+time = { version = "0.2.3", default-features = false }
 open-ssl = { version="0.10", package="openssl", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Mainly minor  changes. Type inference can be used alongside the new `time::parse` method, such that the type doesn't need to be specified. This will be useful if a refactoring takes place that changes the type. There are also new macros, which are used where possible.

One change that is not immediately obvious, in `HttpDate`, there was an unnecessary conditional. As the time crate allows for negative durations (and can perform arithmetic with such), the if/else can be removed entirely.

Time v0.2.3 also has some bug fixes, which is why I am not using a more general v0.2 in Cargo.toml.

---

I'm creating a PR because comments (and thus reviews) were restricted in the main actix repo for whatever reason. I promise this is the last from me! Your PR should be all set to merge with these changes. :tada:   