### PR TITLE
Upgrade to time v0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ regex = "1.3"
 serde = { version = "1.0", features=["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.3", default-features = false }
+time = { version = "0.2.4", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { version="0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.16.0", package = "rustls", optional = true }

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -76,7 +76,7 @@ serde_json = "1.0"
 sha-1 = "0.8"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.3", default-features = false }
+time = { version = "0.2.4", default-features = false, features = ["std"] }
 
 # for secure cookie
 ring = { version = "0.16.9", optional = true }

--- a/actix-identity/Cargo.toml
+++ b/actix-identity/Cargo.toml
@@ -21,7 +21,7 @@ actix-service = "1.0.2"
 futures = "0.3.1"
 serde = "1.0"
 serde_json = "1.0"
-time = { version = "0.2.3", default-features = false }
+time = { version = "0.2.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/actix-session/Cargo.toml
+++ b/actix-session/Cargo.toml
@@ -29,7 +29,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 serde = "1.0"
 serde_json = "1.0"
-time = { version = "0.2.3", default-features = false }
+time = { version = "0.2.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = "1.0"
 sha1 = "0.6"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.3", default-features = false }
+time = { version = "0.2.4", default-features = false, features = ["std"] }
 open-ssl = { version="0.10", package="openssl", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
v0.2.3 has been yanked, as it was backwards imcompatible. This version reverts the breaking change, while still supporting rustc back to 1.34.0.

For realsies this time, it's actually the last from me :laughing:   

(I didn't bother checking anything, since changes are otherwise compatible)